### PR TITLE
Fixes bug with expounding on 's/or' specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Fixed
+- [Bug with displaying errors for `s/or` specs](https://github.com/bhb/expound/issues/64)
+- Bug where "should be one of..." values didn't display correctly
+
 ## [0.4.0] - 2017-12-16
 
 ### Fixed

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject expound "0.4.0"
+(defproject expound "0.4.1-SNAPSHOT"
   :description "Human-optimized error messages for clojure.spec"
   :url "https://github.com/bhb/expound"
   :license {:name "Eclipse Public License"

--- a/src/expound/alpha.cljc
+++ b/src/expound/alpha.cljc
@@ -247,7 +247,7 @@
     (printer/format
      "should be%s: %s"
      (if (= 1 (count combined-set)) "" " one of")
-     (string/join "," (map #(str "`" % "`") combined-set)))))
+     (string/join ", " (sort (map #(str "" (pr-str %) "") combined-set))))))
 
 (defmethod problem-group-str :problem/not-in-set [_type spec-name val path problems opts]
   (assert (apply = (map :val problems)) (str util/assert-message ": All values should be the same, but they are " problems))

--- a/src/expound/alpha.cljc
+++ b/src/expound/alpha.cljc
@@ -8,7 +8,8 @@
             [clojure.set :as set]
             #?(:cljs [goog.string.format])
             #?(:cljs [goog.string])
-            [expound.printer :as printer]))
+            [expound.printer :as printer]
+            [expound.util :as util]))
 
 ;;;;;; specs   ;;;;;;
 
@@ -230,7 +231,7 @@
   (explain-missing-keys problems))
 
 (defmethod problem-group-str :problem/missing-key [_type spec-name val path problems opts]
-  (assert (apply = (map :val problems)) (str "All values should be the same, but they are " problems))
+  (assert (apply = (map :val problems)) (str util/assert-message ": All values should be the same, but they are " problems))
   (printer/format
    "%s
 
@@ -249,7 +250,7 @@
      (string/join "," (map #(str "`" % "`") combined-set)))))
 
 (defmethod problem-group-str :problem/not-in-set [_type spec-name val path problems opts]
-  (assert (apply = (map :val problems)) (str "All values should be the same, but they are " problems))
+  (assert (apply = (map :val problems)) (str util/assert-message ": All values should be the same, but they are " problems))
   (printer/format
    "%s
 
@@ -443,7 +444,7 @@ should satisfy
    (preds problems)))
 
 (defmethod problem-group-str :problem/unknown [_type spec-name val path problems opts]
-  (assert (apply = (map :val problems)) (str "All values should be the same, but they are " problems))
+  (assert (apply = (map :val problems)) (str util/assert-message ": All values should be the same, but they are " problems))
   (printer/format
    "%s
 

--- a/src/expound/alpha.cljc
+++ b/src/expound/alpha.cljc
@@ -500,8 +500,8 @@ should satisfy
 
 %s
 Detected %s %s\n"
-             (string/join "\n\n" (for [[[in type] problems] problems]
-                                   (problem-group-str1 type (spec-name explain-data) form in problems opts')))
+             (string/join "\n\n" (for [[[in type] probs] problems]
+                                   (problem-group-str1 type (spec-name explain-data) form in probs opts')))
              (section-label)
              (count problems)
              (if (= 1 (count problems)) "error" "errors")))))))))

--- a/src/expound/printer.cljc
+++ b/src/expound/printer.cljc
@@ -4,6 +4,7 @@
             [clojure.pprint :as pprint]
             [clojure.walk :as walk]
             [clojure.set :as set]
+            [expound.util :as util]
             #?(:clj [clojure.main :as clojure.main]))
   (:refer-clojure :exclude [format]))
 
@@ -63,7 +64,7 @@
 
 (defn key->spec [keys problems]
   (doseq [p problems]
-    (assert (some? (:expound/via p))))
+    (assert (some? (:expound/via p)) util/assert-message))
   (let [vias (map :expound/via problems)]
     (let [specs (if (every? qualified-keyword? keys)
                   keys

--- a/src/expound/printer.cljc
+++ b/src/expound/printer.cljc
@@ -196,7 +196,7 @@
            string/trim))))
 
 (defn print-missing-keys [problems]
-  (let [keys-clauses (map (comp missing-key :pred) problems)]
+  (let [keys-clauses (distinct (map (comp missing-key :pred) problems))]
     (if (every? keyword? keys-clauses)
       (string/join ", " (sort (map #(str "`" % "`") keys-clauses)))
       (str "\n\n"

--- a/src/expound/util.cljc
+++ b/src/expound/util.cljc
@@ -1,5 +1,7 @@
 (ns expound.util)
 
+(def assert-message "Internal Expound assertion failed. Please report this bug at https://github.com/bhb/expound/issues")
+
 (defn nan? [x]
   #?(:clj (and (number? x) (Double/isNaN x))
      :cljs (and (number? x) (js/isNaN x))))

--- a/test/expound/alpha_test.cljc
+++ b/test/expound/alpha_test.cljc
@@ -350,7 +350,25 @@ should contain keys: `:or-spec/int`, `:or-spec/str`
 -------------------------
 Detected 1 error
 "
-         (expound/expound-str :or-spec/m-with-str-or-int {}))))
+         (expound/expound-str :or-spec/m-with-str-or-int {})))
+  (testing "de-dupes keys"
+    (is (= "-- Spec failed --------------------
+
+  {}
+
+should contain keys: `:or-spec/str`
+
+|          key |    spec |
+|--------------+---------|
+| :or-spec/str | string? |
+
+
+
+-------------------------
+Detected 1 error
+"
+           (expound/expound-str (s/or :m-with-str1 (s/keys :req [:or-spec/str])
+                                      :m-with-int2 (s/keys :req [:or-spec/str])) {})))))
 
 (s/def :and-spec/name (s/and string? #(pos? (count %))))
 (s/def :and-spec/names (s/coll-of :and-spec/name))

--- a/test/expound/alpha_test.cljc
+++ b/test/expound/alpha_test.cljc
@@ -27,6 +27,7 @@
 
 ;; Missing onyx specs
 (s/def :trigger/materialize any?)
+(s/def :flow/short-circuit any?)
 
 (def any-printable-wo-nan (gen/such-that (complement test-utils/contains-nan?) gen/any-printable))
 
@@ -103,7 +104,7 @@ Detected 1 error\n")
 
   :baz
 
-should be one of: `:bar`,`:foo`
+should be one of: :bar, :foo
 
 -- Relevant specs -------
 
@@ -120,7 +121,7 @@ Detected 1 error\n"
   [:three]
    ^^^^^^
 
-should be one of: `:one`,`:two`
+should be one of: :one, :two
 
 -- Relevant specs -------
 
@@ -141,7 +142,7 @@ Detected 1 error\n")
 
   :baz
 
-should be one of: `:bar`,`:foo`
+should be one of: :bar, :foo
 
 -- Relevant specs -------
 
@@ -172,7 +173,7 @@ Detected 2 errors\n")
 
   :baz
 
-should be: `:foobar`
+should be: :foobar
 
 -- Relevant specs -------
 
@@ -311,7 +312,7 @@ Detected 1 error
 
   50
 
-should be one of: `1`,`a`,`2`,`b`
+should be one of: \"a\", \"b\", 1, 2
 
 
 
@@ -323,7 +324,7 @@ Detected 1 error
            :letters #{"a" "b"}
            :ints #{1 2})
           50)))
-  (is (= "-- Spec failed --------------------
+  (is (= (pf "-- Spec failed --------------------
 
   {}
 
@@ -337,11 +338,11 @@ should contain keys: `:or-spec/int`, `:or-spec/str`
 -- Relevant specs -------
 
 :or-spec/m-with-int:
-  (clojure.spec.alpha/keys :req [:or-spec/int])
+  (pf.spec.alpha/keys :req [:or-spec/int])
 :or-spec/m-with-str:
-  (clojure.spec.alpha/keys :req [:or-spec/str])
+  (pf.spec.alpha/keys :req [:or-spec/str])
 :or-spec/m-with-str-or-int:
-  (clojure.spec.alpha/or
+  (pf.spec.alpha/or
    :m-with-str
    :or-spec/m-with-str
    :m-with-int
@@ -349,7 +350,7 @@ should contain keys: `:or-spec/int`, `:or-spec/str`
 
 -------------------------
 Detected 1 error
-"
+")
          (expound/expound-str :or-spec/m-with-str-or-int {})))
   (testing "de-dupes keys"
     (is (= "-- Spec failed --------------------
@@ -491,7 +492,7 @@ Detected 1 error\n")
 
   []
 
-should have additional elements. The next element \":type\" should be one of: `:bar`,`:foo`
+should have additional elements. The next element \":type\" should be one of: :bar, :foo
 
 -- Relevant specs -------
 
@@ -1662,7 +1663,7 @@ Detected 1 error\n"
 (deftest test-assert2
   (is (thrown-with-msg?
        #?(:cljs :default :clj Exception)
-       #"\"Key must be integer\"\n\nshould be one of: `Extra input`,`Insufficient input`,`no method`"
+       #"\"Key must be integer\"\n\nshould be one of: \"Extra input\", \"Insufficient input\", \"no method"
        (binding [s/*explain-out* expound/printer]
          (s/assert (s/nilable #{"Insufficient input" "Extra input" "no method"}) "Key must be integer")))))
 

--- a/test/expound/alpha_test.cljc
+++ b/test/expound/alpha_test.cljc
@@ -239,8 +239,8 @@ Detected 1 error\n")
 
 (s/def :or-spec/str string?)
 (s/def :or-spec/int int?)
-(s/def :or-spec/m-with-str (s/keys :req [:or-specs/str]))
-(s/def :or-spec/m-with-int (s/keys :req [:or-specs/str]))
+(s/def :or-spec/m-with-str (s/keys :req [:or-spec/str]))
+(s/def :or-spec/m-with-int (s/keys :req [:or-spec/int]))
 (s/def :or-spec/m-with-str-or-int (s/or :m-with-str :or-spec/m-with-str
                                         :m-with-int :or-spec/m-with-int))
 
@@ -327,18 +327,19 @@ Detected 1 error
 
   {}
 
-should contain keys: `:or-specs/str`, `:or-specs/str`
+should contain keys: `:or-spec/int`, `:or-spec/str`
 
-|           key |          spec |
-|---------------+---------------|
-| :or-specs/str | :or-specs/str |
+|          key |    spec |
+|--------------+---------|
+| :or-spec/int |    int? |
+| :or-spec/str | string? |
 
 -- Relevant specs -------
 
 :or-spec/m-with-int:
-  (clojure.spec.alpha/keys :req [:or-specs/str])
+  (clojure.spec.alpha/keys :req [:or-spec/int])
 :or-spec/m-with-str:
-  (clojure.spec.alpha/keys :req [:or-specs/str])
+  (clojure.spec.alpha/keys :req [:or-spec/str])
 :or-spec/m-with-str-or-int:
   (clojure.spec.alpha/or
    :m-with-str


### PR DESCRIPTION
Fixes https://github.com/bhb/expound/issues/64

Also improves "should be one of" reporting to more clearly print strings