### PR TITLE
fix typo in expound.problems/summary-form spec

### DIFF
--- a/src/expound/problems.cljc
+++ b/src/expound/problems.cljc
@@ -24,7 +24,7 @@
     ::irrelevant))
 
 (s/fdef summary-form
-        :args (s/cat :show-valid-valids? boolean?
+        :args (s/cat :show-valid-values? boolean?
                      :form any?
                      :highlighted-path :expound/path))
 (defn summary-form [show-valid-values? form in]


### PR DESCRIPTION
`:show-valid-valids?` -> `:show-valid-values?`