### PR TITLE
Some sensible formatting

### DIFF
--- a/src/expound/paths.cljc
+++ b/src/expound/paths.cljc
@@ -202,10 +202,14 @@
     1
 
     (and (vector? x) (vector? y))
-    (first (filter #(not= 0 %) (map compare-path-segment x y)))
+    (->> (map compare-path-segment x y)
+         (remove #{0})
+         first)
 
     :else
     (compare x y)))
 
 (defn compare-paths [path1 path2]
-  (first (filter #(not= 0 %) (map compare-path-segment path1 path2))))
+  (->> (map compare-path-segment path1 path2)
+       (remove #{0})
+       first))

--- a/src/expound/printer.cljc
+++ b/src/expound/printer.cljc
@@ -66,23 +66,23 @@
 (defn key->spec [keys problems]
   (doseq [p problems]
     (assert (some? (:expound/via p)) util/assert-message))
-  (let [vias (map :expound/via problems)]
-    (let [specs (if (every? qualified-keyword? keys)
-                  keys
-                  (if-let [specs (apply set/union (map specs-from-form vias))]
-                    specs
-                    keys))]
-      (reduce
-       (fn [m k]
-         (assoc m
+  (let [vias (map :expound/via problems)
+        specs (if (every? qualified-keyword? keys)
+                keys
+                (if-let [specs (apply set/union (map specs-from-form vias))]
+                  specs
+                  keys))]
+    (reduce
+     (fn [m k]
+       (assoc m
+              k
+              (if (qualified-keyword? k)
                 k
-                (if (qualified-keyword? k)
-                  k
-                  (->> specs
-                       (filter #(= (name k) (name %)))
-                       first))))
-       {}
-       keys))))
+                (->> specs
+                     (filter #(= (name k) (name %)))
+                     first))))
+     {}
+     keys)))
 
 (defn expand-spec [spec]
   (let [!seen-specs (atom #{})]

--- a/src/expound/printer.cljc
+++ b/src/expound/printer.cljc
@@ -240,6 +240,7 @@
    (indent indent-level indent-level s))
   ([first-line-indent rest-lines-indent s]
    (let [[line & lines] (string/split-lines (str s))]
-     (string/join "\n"
-                  (into [(str (apply str (repeat first-line-indent " ")) line)]
-                        (map #(str (apply str (repeat rest-lines-indent " ")) %) lines))))))
+     (->> lines
+          (map #(str (apply str (repeat rest-lines-indent " ")) %))
+          (into [(str (apply str (repeat first-line-indent " ")) line)])
+          (string/join "\n")))))

--- a/src/expound/problems.cljc
+++ b/src/expound/problems.cljc
@@ -37,11 +37,10 @@
       ::relevant
 
       (and (map? form) (paths/kps? k))
-      (assoc
-       (dissoc displayed-form
-               (:key k))
-       (summary-form show-valid-values? (:key k) rst)
-       ::irrelevant)
+      (-> displayed-form
+          (dissoc (:key k))
+          (assoc (summary-form show-valid-values? (:key k) rst)
+                 ::irrelevant))
 
       (and (map? form) (paths/kvps? k))
       (recur show-valid-values? (nth (seq form) (:idx k)) rst)


### PR DESCRIPTION
Hey there,

I'm having a cool time reading the expound source.

Found a few points where formatting might be welcome:

* Use ->> where it seemed good beyond doubt
* Use `(remove #{0})` idiom
* Consolidate `(let [...] (let [...]))` into just one let

Cheers - Victor