### PR TITLE
Make multimethods public, check for explicit problem type

### DIFF
--- a/src/expound/alpha.cljc
+++ b/src/expound/alpha.cljc
@@ -303,8 +303,8 @@
      (pr-str retag)
      (pr-str (if retag (retag (problems/value-in val path)) nil)))))
 
-(defmulti ^:private problem-group-str (fn [type spec-name _val _path _problems _opts] type))
-(defmulti ^:private expected-str (fn [type  spec-name _val _path _problems _opts] type))
+(defmulti ^:no-doc problem-group-str (fn [type spec-name _val _path _problems _opts] type))
+(defmulti ^:no-doc expected-str (fn [type  spec-name _val _path _problems _opts] type))
 
 (defn ^:private explain-missing-keys [problems]
   (let [missing-keys (map #(printer/missing-key (:pred %)) problems)]
@@ -381,6 +381,9 @@
 
 (defn ^:private problem-type [failure problem]
   (cond
+    (:expound.spec.problem/type problem)
+    (:expound.spec.problem/type problem)
+
     (insufficient-input? failure problem)
     :problem/insufficient-input
 

--- a/src/expound/alpha.cljc
+++ b/src/expound/alpha.cljc
@@ -381,7 +381,7 @@
 
 (defn ^:private problem-type [failure problem]
   (cond
-    (:expound.spec.problem/type problem)
+    (get-method problem-group-str (:expound.spec.problem/type problem))
     (:expound.spec.problem/type problem)
 
     (insufficient-input? failure problem)

--- a/test/expound/alpha_test.cljc
+++ b/test/expound/alpha_test.cljc
@@ -2722,4 +2722,22 @@ should satisfy
                        ::test-problem2)]
 
       (is (= "fake-problem-group-str\nfake-expected-str\n\n-------------------------\nDetected 1 error\n"
+             (printer-str {:print-specs? false} ed)))))
+  (testing "if type has no mm implemented, behavior is normal expound behavior"
+    (let [printer-str #'expound/printer-str
+          ed (assoc-in (s/explain-data int? "")
+                       [::s/problems 0 :expound.spec.problem/type]
+                       ::test-problem3)]
+
+      (is (= "-- Spec failed --------------------
+
+  \"\"
+
+should satisfy
+
+  int?
+
+-------------------------
+Detected 1 error
+"
              (printer-str {:print-specs? false} ed))))))

--- a/test/expound/alpha_test.cljc
+++ b/test/expound/alpha_test.cljc
@@ -2695,3 +2695,31 @@ should satisfy
 ")
          (binding [s/*explain-out* (expound/custom-printer {:theme :figwheel-theme})]
            (readable-ansi (s/explain-str :colorized-output/strings ["" :a ""]))))))
+
+(defmethod expound/problem-group-str ::test-problem1 [_type spec-name val path problems opts]
+  "fake-problem-group-str")
+
+(defmethod expound/problem-group-str ::test-problem2 [type spec-name val path problems opts]
+  (str "fake-problem-group-str\n"
+       (expound/expected-str type spec-name val path problems opts)))
+
+(defmethod expound/expected-str ::test-problem2 [_type spec-name val path problems opts]
+  "fake-expected-str")
+
+(deftest extensibility-test
+  (testing "can overwrite entire message"
+    (let [printer-str #'expound/printer-str
+          ed (assoc-in (s/explain-data int? "")
+                       [::s/problems 0 :expound.spec.problem/type]
+                       ::test-problem1)]
+
+      (is (= "fake-problem-group-str\n\n-------------------------\nDetected 1 error\n"
+             (printer-str {:print-specs? false} ed)))))
+  (testing "can overwrite 'expected' str"
+    (let [printer-str #'expound/printer-str
+          ed (assoc-in (s/explain-data int? "")
+                       [::s/problems 0 :expound.spec.problem/type]
+                       ::test-problem2)]
+
+      (is (= "fake-problem-group-str\nfake-expected-str\n\n-------------------------\nDetected 1 error\n"
+             (printer-str {:print-specs? false} ed))))))


### PR DESCRIPTION
This opens to door to allowing external libraries to control how expound prints problems from other types of specs.

I'd like to refine the extensibility for expound for the eventual beta version, but hopefully this will work in a pinch.