### PR TITLE
honor ansi/*enable-color* if already bound and color isn't already config-ed

### DIFF
--- a/src/expound/alpha.cljc
+++ b/src/expound/alpha.cljc
@@ -752,10 +752,12 @@ returned an invalid value.
 (defn ^:private printer-str [opts data]
   (let [opts' (merge {:show-valid-values? false
                       :print-specs? true}
-                     opts)]
+                     opts)
+        enable-color? (or (not= :none (get opts :theme :none))
+                          ansi/*enable-color*)]
     (binding [*value-str-fn* (get opts :value-str-fn (partial value-in-context opts'))
-              ansi/*enable-color* (not= :none (get opts :theme :none))
-              ansi/*print-styles* (case (get opts :theme :none)
+              ansi/*enable-color* enable-color?
+              ansi/*print-styles* (case (get opts :theme (if enable-color? :figwheel-theme :none))
                                     :figwheel-theme
                                     figwheel-theme
 


### PR DESCRIPTION
This allows one to express `(ansi/with-color (expound spec data))` or rather allows one to place the `ansi/*enable-color*` binding much higher in order to allow color from a more general context.