### PR TITLE
Fix macroexpand error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. This change
 
 ### Fixed
 - [Bug with printing alternatives in 'or' or 'alt' specs](https://github.com/bhb/expound/issues/73)
+- [Bug with missing elements in `cat` specs](https://github.com/bhb/expound/issues/79)
 
 ### Changed
 - If a problem has a value for `:expound.spec.problem/type` key, `expound.alpha/problem-group-str` must be implemented for that value or Expound will throw an error.

--- a/src/expound/alpha.cljc
+++ b/src/expound/alpha.cljc
@@ -503,7 +503,7 @@
   (let [problem (first problems)]
     (printer/format
      "should have additional elements. The next element%s %s"
-     (if-some [el-name (first (:expound/path problem))]
+     (if-some [el-name (last (:expound/path problem))]
        (str " \"" (pr-str el-name) "\"")
        "")
      (let [failure nil
@@ -974,4 +974,3 @@ returned an invalid value.
   "Given a sequence of results from `clojure.spec.test.alpha/check`, returns a string summarizing the results."
   [check-results]
   (with-out-str (explain-results check-results)))
-

--- a/test/expound/alpha_test.cljc
+++ b/test/expound/alpha_test.cljc
@@ -3267,8 +3267,8 @@ should satisfy
            #"No method in multimethod"
            (printer-str {:print-specs? false} ed))))))
 
-(deftest macroexpansion-errors
-  (is (thrown-with-msg?
-       #?(:cljs :default :clj Exception)
-       #"should have additional elements. The next element \"\:init\-expr\" should satisfy"
-       (macroexpand `(let [~'a] 2)))))
+#?(:clj (deftest macroexpansion-errors
+          (is (thrown-with-msg?
+               #?(:cljs :default :clj Exception)
+               #"should have additional elements. The next element \"\:init\-expr\" should satisfy"
+               (macroexpand '(clojure.core/let [a] 2))))))

--- a/test/expound/alpha_test.cljc
+++ b/test/expound/alpha_test.cljc
@@ -3266,3 +3266,9 @@ should satisfy
            #?(:cljs :default :clj Exception)
            #"No method in multimethod"
            (printer-str {:print-specs? false} ed))))))
+
+(deftest macroexpansion-errors
+  (is (thrown-with-msg?
+       #?(:cljs :default :clj Exception)
+       #"should have additional elements. The next element \"\:init\-expr\" should satisfy"
+       (macroexpand `(let [~'a] 2)))))


### PR DESCRIPTION
Fixes https://github.com/bhb/expound/issues/79

The issue is really with nested specs for a function or macro spec, but it shows up in more complex specs like `let`