### PR TITLE
Make specs-from-form always return a set

### DIFF
--- a/src/expound/printer.cljc
+++ b/src/expound/printer.cljc
@@ -61,7 +61,7 @@
               (and (vector? x) (= :kw (first x)))))
            (map second)
            set)
-      [])))
+      #{})))
 
 (defn key->spec [keys problems]
   (doseq [p problems]


### PR DESCRIPTION
Feels slightly silly to open a PR for something that doesn't cause any actual problems at the moment, but, well, here we go…

Given something like this:

```clojure
(require '[clojure.spec.alpha :as spec])

(spec/def ::x int?)

(spec/def ::m
  (spec/and
    (spec/keys :req-un [::x])
    #(not (contains? % :y))))

(expound.alpha/expound ::m {})
```

`expound.printer/specs-from-form` returns a vector. In most other cases, it returns a set. The return value of `specs-from-form` then flows to `clojure.set/union`, which (implicitly) expects a set, and can [behave](https://dev.clojure.org/jira/browse/CLJ-1682) [unexpectedly](https://dev.clojure.org/jira/browse/CLJ-1953) when given some other type of collection.

As I mentioned, I don't know that this causes any actual issue here, but I just happened to notice it when experimenting with a set of specs I wrote for my own use for the functions in the clojure.set namespace.