### PR TITLE
Fix groupings

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :aliases {;; clj -A:test
+ :aliases {;; clj -Atest
            :test {:extra-paths ["test"]
                   :extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
                                                           :sha "3cb0a9daf1cb746259dc8309b218f9211ad3b33b"}
@@ -15,8 +15,7 @@
                                com.bhauman/spell-spec {:mvn/version "0.1.1"}}
                   ;; Taken from https://github.com/boot-clj/boot/wiki/Improving-startup-time
                   :jvm-opts ["-client " "-XX:+TieredCompilation" "-XX:TieredStopAtLevel=1" "-Xmx2g" "-XX:+UseConcMarkSweepGC" "-XX:+CMSClassUnloadingEnabled" "-Xverify:none"]
-                  :main-opts ["-m" "cognitect.test-runner"] 
-                  }
+                  :main-opts ["-m" "cognitect.test-runner"]}
            ;; clj -A:lint:lint/fix
            :lint {:extra-deps {com.jameslaverack/cljfmt-runner
                                {:git/url "https://github.com/JamesLaverack/cljfmt-runner"

--- a/deps.edn
+++ b/deps.edn
@@ -17,10 +17,6 @@
                   :jvm-opts ["-client " "-XX:+TieredCompilation" "-XX:TieredStopAtLevel=1" "-Xmx2g" "-XX:+UseConcMarkSweepGC" "-XX:+CMSClassUnloadingEnabled" "-Xverify:none"]
                   :main-opts ["-m" "cognitect.test-runner"] 
                   }
-           ; :runner {:extra-deps {com.cognitect/test-runner
-           ;                       {:git/url "https://github.com/cognitect-labs/test-runner"
-           ;                        :sha "cb96e80f6f3d3b307c59cbeb49bb0dcb3a2a780b"}}
-           ;          :main-opts ["-m" "cognitect.test-runner" "-d" "test"]}
            ;; clj -A:lint:lint/fix
            :lint {:extra-deps {com.jameslaverack/cljfmt-runner
                                {:git/url "https://github.com/JamesLaverack/cljfmt-runner"

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src"]
- :aliases {;; clj -Atest
+ :aliases {;; clj -A:test
            :test {:extra-paths ["test"]
                   :extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
                                                           :sha "3cb0a9daf1cb746259dc8309b218f9211ad3b33b"}
@@ -15,7 +15,12 @@
                                com.bhauman/spell-spec {:mvn/version "0.1.1"}}
                   ;; Taken from https://github.com/boot-clj/boot/wiki/Improving-startup-time
                   :jvm-opts ["-client " "-XX:+TieredCompilation" "-XX:TieredStopAtLevel=1" "-Xmx2g" "-XX:+UseConcMarkSweepGC" "-XX:+CMSClassUnloadingEnabled" "-Xverify:none"]
-                  :main-opts ["-m" "cognitect.test-runner"]}
+                  :main-opts ["-m" "cognitect.test-runner"] 
+                  }
+           ; :runner {:extra-deps {com.cognitect/test-runner
+           ;                       {:git/url "https://github.com/cognitect-labs/test-runner"
+           ;                        :sha "cb96e80f6f3d3b307c59cbeb49bb0dcb3a2a780b"}}
+           ;          :main-opts ["-m" "cognitect.test-runner" "-d" "test"]}
            ;; clj -A:lint:lint/fix
            :lint {:extra-deps {com.jameslaverack/cljfmt-runner
                                {:git/url "https://github.com/JamesLaverack/cljfmt-runner"

--- a/src/expound/alpha.cljc
+++ b/src/expound/alpha.cljc
@@ -1,7 +1,6 @@
 (ns expound.alpha
   "Generates human-readable errors for `clojure.spec`"
   (:require [expound.problems :as problems]
-            [clojure.pprint :as pprint]
             [clojure.spec.alpha :as s]
             [clojure.string :as string]
             [clojure.set :as set]
@@ -556,12 +555,7 @@
 (defn conj-groups
   "Consolidate a group into a group collection if it's either part of an s/or,
   s/alt or recursive spec."
-  [groups group] 
-  #_(if-let [old-groups-2 (some #(share-alt-tags % group) groups)]
-      (-> groups
-          (remove-vec old-groups-2)
-          (conj (problem-group old-groups-2 group)))
-      (conj groups group))
+  [groups group]
   (if-let [old-groups-1 (some #(recursive-spec % group) groups)]
     ;; Consolidate if we find a recursive spec
     (-> groups

--- a/src/expound/alpha.cljc
+++ b/src/expound/alpha.cljc
@@ -490,7 +490,7 @@
 
 (defn ^:private share-alt-tags
   "Determine if two groups have prefixes (ie. spec tags) that are included in
-  an s/or or s/and predicate. Returns group 1 if true, nil if false."
+  an s/or or s/alt predicate. Returns group 1 if true, nil if false."
   [grp1 grp2]
   (let [pxs (:path-prefix grp1)
         pys (:path-prefix grp2)
@@ -556,7 +556,12 @@
 (defn conj-groups
   "Consolidate a group into a group collection if it's either part of an s/or,
   s/alt or recursive spec."
-  [groups group]
+  [groups group] 
+  #_(if-let [old-groups-2 (some #(share-alt-tags % group) groups)]
+      (-> groups
+          (remove-vec old-groups-2)
+          (conj (problem-group old-groups-2 group)))
+      (conj groups group))
   (if-let [old-groups-1 (some #(recursive-spec % group) groups)]
     ;; Consolidate if we find a recursive spec
     (-> groups
@@ -1094,31 +1099,3 @@ returned an invalid value.
   "Given a sequence of results from `clojure.spec.test.alpha/check`, returns a string summarizing the results."
   [check-results]
   (with-out-str (explain-results check-results)))
-
-(s/def :keys-spec/one string?)
-(s/def :keys-spec/two string?)
-(s/def :keys-spec/three string?)
-(s/def :keys-spec/map-spec (s/keys :req-un [:keys-spec/one
-                                            :keys-spec/two
-                                            :keys-spec/three]))
-; (expound :keys-spec/map-spec {:one 1.2 :two 123 :three true})
-
-(s/def :and-spec/ne-string (s/and string?
-                                  #(pos? (count %))))
-(s/def :and-spec/ne-strings (s/coll-of :and-spec/ne-string))
-; (expound :and-spec/ne-strings ["bob" "sally" "" 1])
-
-; (s/def :or-spec/foo (s/or :string string? :pos-int pos?))
-; (expound :or-spec/foo -12)
-
-; (s/def :or-spec/bar (s/or :seq0 (s/cat :y1 string? :y2 boolean?) :seq1 (s/cat :x1 int? :x2 int?)))
-; (expound :or-spec/bar ["foo" "bar"])
-
-; (s/def :alt-spec/or-spec (s/alt :one int?
-;                                 :many (s/spec (s/+ int?))))
-; (s/def :alt-spec/baz (s/cat :bs (s/alt :number (s/or :int int?
-;                                                      :float float?)
-;                                        :many (s/spec (s/+ int?)))))
-; (expound :alt-spec/baz [["1"]])
-
-; (s/def ::alt-spec/one-many-int-or-str (s/cat :bs (s/alt :one :alt-spec/)))

--- a/test/expound/alpha_test.cljc
+++ b/test/expound/alpha_test.cljc
@@ -783,8 +783,8 @@ should satisfy
 Detected 3 errors\n") 
            (binding [s/*explain-out* (expound/custom-printer {:print-specs? false})]
              (s/explain-str :keys-spec/map-spec-1 {:foo 1.2
-                                                 :bar 123
-                                                 :baz true}))))
+                                                   :bar 123
+                                                   :baz true}))))
     (is (= (pf 
 "-- Spec failed --------------------
 
@@ -821,8 +821,8 @@ or
 Detected 3 errors\n") 
            (binding [s/*explain-out* (expound/custom-printer {:print-specs? false})]
              (s/explain-str :keys-spec/map-spec-2 {:foo 1.2 
-                                                 :bar 123 
-                                                 :qux false}))))
+                                                   :bar 123 
+                                                   :qux false}))))
     (is (= (pf 
 "-- Spec failed --------------------
 
@@ -874,8 +874,7 @@ Detected 4 errors\n")
              (s/explain-str :keys-spec/map-spec-3 {:foo 1.2 
                                                    :child-2 {:bar 123
                                                              :child-1 {:baz true
-                                                                       :qux false}}}))))
-    ))
+                                                                       :qux false}}}))))))
 
 (s/def :multi-spec/value string?)
 (s/def :multi-spec/children vector?)
@@ -1019,8 +1018,7 @@ Detected 1 error\n")
               {:tag :group
                :children [{:tag :group
                            :children [{:tag :group
-                                       :props {:on-tap {}}}]}]})
-             ))))
+                                       :props {:on-tap {}}}]}]})))))
   ;; XXX New Test
   (testing "test that our new recursive spec grouping function works with
            alternative paths"
@@ -1065,10 +1063,7 @@ Detected 1 error\n")
               {:tag-2 :group
                :children-2 [{:tag-2 :group
                            :children-2 [{:tag-2 :group
-                                       :props-2 {:on-tap-2 {}}}]}]})
-             )
-           )) 
-    ))
+                                       :props-2 {:on-tap-2 {}}}]}]}))))))
 
 (s/def :cat-wrapped-in-or-spec/kv (s/and
                                    sequential?

--- a/test/expound/alpha_test.cljc
+++ b/test/expound/alpha_test.cljc
@@ -611,13 +611,6 @@ Detected 1 error\n")
                                            :key-spec/state
                                            :key-spec/city))]))
 
-(s/def :keys-spec/foo string?)
-(s/def :keys-spec/bar string?)
-(s/def :keys-spec/baz string?)
-(s/def :keys-spec/map-spec (s/keys :req-un [:keys-spec/foo
-                                          :keys-spec/bar
-                                          :keys-spec/baz]))
-
 (deftest keys-spec
   (testing "missing keys"
     (is (= (pf "-- Spec failed --------------------
@@ -734,8 +727,32 @@ should satisfy
 Detected 1 error\n"
                #?(:cljs "(cljs.spec.alpha/keys :req [:keys-spec/name] :req-un [:keys-spec/age])"
                   :clj "(clojure.spec.alpha/keys\n   :req\n   [:keys-spec/name]\n   :req-un\n   [:keys-spec/age])"))
-           (expound/expound-str :keys-spec/user {:age 1 :keys-spec/name :bob})))
-    (is (= (pf "-- Spec failed --------------------
+           (expound/expound-str :keys-spec/user {:age 1 :keys-spec/name :bob})))))
+
+(s/def :keys-spec/foo string?)
+(s/def :keys-spec/bar string?)
+(s/def :keys-spec/baz string?)
+(s/def :keys-spec/qux (s/or :string string?
+                            :int int?))
+(s/def :keys-spec/child-1 (s/keys :req-un [:keys-spec/baz :keys-spec/qux]))
+(s/def :keys-spec/child-2 (s/keys :req-un [:keys-spec/bar :keys-spec/child-1]))
+
+(s/def :keys-spec/map-spec-1 (s/keys :req-un [:keys-spec/foo
+                                          :keys-spec/bar
+                                          :keys-spec/baz]))
+(s/def :keys-spec/map-spec-2 (s/keys :req-un [:keys-spec/foo
+                                              :keys-spec/bar
+                                              :keys-spec/qux]))
+(s/def :keys-spec/map-spec-3 (s/keys :req-un [:keys-spec/foo
+                                              :keys-spec/child-2]))
+
+
+;; XXX New Tests
+;; Make sure that our changes work with s/keys
+(deftest keys-spec-2
+  (testing "More advanced key specs"
+    (is (= (pf 
+"-- Spec failed --------------------
 
   {:foo 1.2, :bar ..., :baz ...}
         ^^^
@@ -765,9 +782,100 @@ should satisfy
 -------------------------
 Detected 3 errors\n") 
            (binding [s/*explain-out* (expound/custom-printer {:print-specs? false})]
-             (s/explain-str :keys-spec/map-spec {:foo 1.2
-                                                       :bar 123
-                                                       :baz true}))))))
+             (s/explain-str :keys-spec/map-spec-1 {:foo 1.2
+                                                 :bar 123
+                                                 :baz true}))))
+    (is (= (pf 
+"-- Spec failed --------------------
+
+  {:foo 1.2, :bar ..., :qux ...}
+        ^^^
+
+should satisfy
+
+  string?
+
+-- Spec failed --------------------
+
+  {:foo ..., :bar 123, :qux ...}
+                  ^^^
+
+should satisfy
+
+  string?
+
+-- Spec failed --------------------
+
+  {:foo ..., :bar ..., :qux false}
+                            ^^^^^
+
+should satisfy
+
+  string?
+
+or
+
+  int?
+
+-------------------------
+Detected 3 errors\n") 
+           (binding [s/*explain-out* (expound/custom-printer {:print-specs? false})]
+             (s/explain-str :keys-spec/map-spec-2 {:foo 1.2 
+                                                 :bar 123 
+                                                 :qux false}))))
+    (is (= (pf 
+"-- Spec failed --------------------
+
+  {:foo 1.2, :child-2 ...}
+        ^^^
+
+should satisfy
+
+  string?
+
+-- Spec failed --------------------
+
+  {:foo ..., :child-2 {:bar 123, :child-1 ...}}
+                            ^^^
+
+should satisfy
+
+  string?
+
+-- Spec failed --------------------
+
+  {:foo ...,
+   :child-2
+   {:bar ..., :child-1 {:baz true, :qux ...}}}
+                             ^^^^
+
+should satisfy
+
+  string?
+
+-- Spec failed --------------------
+
+  {:foo ...,
+   :child-2
+   {:bar ..., :child-1 {:baz ..., :qux false}}}
+                                       ^^^^^
+
+should satisfy
+
+  string?
+
+or
+
+  int?
+
+-------------------------
+Detected 4 errors\n") 
+           (binding [s/*explain-out* (expound/custom-printer {:print-specs? false})]
+             (s/explain-str :keys-spec/map-spec-3 {:foo 1.2 
+                                                   :child-2 {:bar 123
+                                                             :child-1 {:baz true
+                                                                       :qux false}}}))))
+    ))
 
 (s/def :multi-spec/value string?)
 (s/def :multi-spec/children vector?)
@@ -858,6 +966,16 @@ Detected 1 error\n")
                                   :opt-un [:recursive-spec/props :recursive-spec/children]))
 (s/def :recursive-spec/children (s/coll-of (s/nilable :recursive-spec/el) :kind vector?))
 
+(s/def :recursive-spec/tag-2 (s/or :text (fn [n] (= n :text))
+                                  :group (fn [n] (= n :group))))
+(s/def :recursive-spec/on-tap-2 (s/coll-of map? :kind vector?))
+(s/def :recursive-spec/props-2 (s/keys :opt-un [:recursive-spec/on-tap-2]))
+(s/def :recursive-spec/el-2 (s/keys :req-un [:recursive-spec/tag-2]
+                                    :opt-un [:recursive-spec/props-2
+                                             :recursive-spec/children-2
+                                             ]))
+(s/def :recursive-spec/children-2 (s/coll-of (s/nilable :recursive-spec/el-2) :kind vector?))
+
 (deftest recursive-spec
   (testing "only shows problem with data at 'leaves' (not problems with all parents in tree)"
     (is (= (pf
@@ -902,7 +1020,55 @@ Detected 1 error\n")
                :children [{:tag :group
                            :children [{:tag :group
                                        :props {:on-tap {}}}]}]})
-             )))))
+             ))))
+  ;; XXX New Test
+  (testing "test that our new recursive spec grouping function works with
+           alternative paths"
+    (is (= (pf 
+"-- Spec failed --------------------
+
+  {:tag-2 ..., :children-2 [{:tag-2 :group, :children-2 [{:tag-2 :group, :props-2 {:on-tap-2 {}}}]}]}
+                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+should satisfy
+
+  nil?
+
+or value
+
+  {:tag-2 ...,
+   :children-2 [{:tag-2 ..., :children-2 [{:tag-2 :group, :props-2 {:on-tap-2 {}}}]}]}
+                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+should satisfy
+
+  nil?
+
+or value
+
+  {:tag-2 ...,
+   :children-2
+   [{:tag-2 ...,
+     :children-2
+     [{:tag-2 ..., :props-2 {:on-tap-2 {}}}]}]}
+                                       ^^
+
+should satisfy
+
+  vector?
+
+-------------------------
+Detected 1 error\n") 
+           (binding [s/*explain-out* (expound/custom-printer {:print-specs? false})]
+             (s/explain-str
+              :recursive-spec/el-2
+              {:tag-2 :group
+               :children-2 [{:tag-2 :group
+                           :children-2 [{:tag-2 :group
+                                       :props-2 {:on-tap-2 {}}}]}]})
+             )
+           )) 
+    ))
 
 (s/def :cat-wrapped-in-or-spec/kv (s/and
                                    sequential?
@@ -1864,7 +2030,7 @@ Detected 1 error\n"
              (s/explain-str
               :alt-spec/one-many-int-or-str
               [[:one]])))))
-  (is (=  (pf "-- Spec failed --------------------
+  (is (= (pf "-- Spec failed --------------------
 
   [:hi]
    ^^^
@@ -1891,6 +2057,96 @@ Detected 1 error\n"
    clojure.core/string?)"
                  :cljs "(cljs.spec.alpha/alt :int cljs.core/int? :string cljs.core/string?)"))
           (expound/expound-str :alt-spec/int-alt-str [:hi]))))
+
+(s/def :alt-spec/num-types (s/alt :int int? :float float?))
+(s/def :alt-spec/str-types (s/alt :int (fn [n] (= n "int")) 
+                                  :float (fn [n] (= n "float"))))
+(s/def :alt-spec/num-or-str (s/alt :num :alt-spec/num-types
+                                   :str :alt-spec/str-types))
+
+;; XXX New Tests
+(deftest alt-spec-2
+  (testing "more specs involving alternatives"
+    (is (= (pf
+"-- Spec failed --------------------
+
+  [true]
+   ^^^^
+
+should satisfy
+
+  int?
+
+or
+
+  float?
+
+or
+
+  (fn [n] (= n \"int\"))
+
+or
+
+  (fn [n] (= n \"float\"))
+
+-- Relevant specs -------
+
+:alt-spec/str-types:
+  (clojure.spec.alpha/alt
+   :int
+   (clojure.core/fn [n] (clojure.core/= n \"int\"))
+   :float
+   (clojure.core/fn [n] (clojure.core/= n \"float\")))
+:alt-spec/num-types:
+  (clojure.spec.alpha/alt
+   :int
+   clojure.core/int?
+   :float
+   clojure.core/float?)
+:alt-spec/num-or-str:
+  (clojure.spec.alpha/alt
+   :num
+   :alt-spec/num-types
+   :str
+   :alt-spec/str-types)
+
+-------------------------
+Detected 1 error\n") (expound/expound-str :alt-spec/num-or-str [true])))
+    ;; If two s/alt specs have the same tags, we shouldn't confuse them.
+   (is (= (pf
+"-- Spec failed --------------------
+
+  {:num-types [true], :str-types ...}
+               ^^^^
+
+should satisfy
+
+  int?
+
+or
+
+  float?
+
+-- Spec failed --------------------
+
+  {:num-types ..., :str-types [false]}
+                               ^^^^^
+
+should satisfy
+
+  (fn [n] (= n \"int\"))
+
+or
+
+  (fn [n] (= n \"float\"))
+
+-------------------------
+Detected 2 errors\n")
+          (binding [s/*explain-out* (expound/custom-printer {:print-specs? false})]
+             (s/explain-str (s/keys :req-un [:alt-spec/num-types :alt-spec/str-types])                 
+                 {:num-types [true] :str-types [false]}))    
+          )) 
+    ))
 
 #?(:clj
    (def spec-gen (gen/elements (->> (s/registry)

--- a/test/expound/alpha_test.cljc
+++ b/test/expound/alpha_test.cljc
@@ -611,6 +611,13 @@ Detected 1 error\n")
                                            :key-spec/state
                                            :key-spec/city))]))
 
+(s/def :keys-spec/foo string?)
+(s/def :keys-spec/bar string?)
+(s/def :keys-spec/baz string?)
+(s/def :keys-spec/map-spec (s/keys :req-un [:keys-spec/foo
+                                          :keys-spec/bar
+                                          :keys-spec/baz]))
+
 (deftest keys-spec
   (testing "missing keys"
     (is (= (pf "-- Spec failed --------------------
@@ -727,7 +734,40 @@ should satisfy
 Detected 1 error\n"
                #?(:cljs "(cljs.spec.alpha/keys :req [:keys-spec/name] :req-un [:keys-spec/age])"
                   :clj "(clojure.spec.alpha/keys\n   :req\n   [:keys-spec/name]\n   :req-un\n   [:keys-spec/age])"))
-           (expound/expound-str :keys-spec/user {:age 1 :keys-spec/name :bob})))))
+           (expound/expound-str :keys-spec/user {:age 1 :keys-spec/name :bob})))
+    (is (= (pf "-- Spec failed --------------------
+
+  {:foo 1.2, :bar ..., :baz ...}
+        ^^^
+
+should satisfy
+
+  string?
+
+-- Spec failed --------------------
+
+  {:foo ..., :bar 123, :baz ...}
+                  ^^^
+
+should satisfy
+
+  string?
+
+-- Spec failed --------------------
+
+  {:foo ..., :bar ..., :baz true}
+                            ^^^^
+
+should satisfy
+
+  string?
+
+-------------------------
+Detected 3 errors\n") 
+           (binding [s/*explain-out* (expound/custom-printer {:print-specs? false})]
+             (s/explain-str :keys-spec/map-spec {:foo 1.2
+                                                       :bar 123
+                                                       :baz true}))))))
 
 (s/def :multi-spec/value string?)
 (s/def :multi-spec/children vector?)
@@ -861,7 +901,8 @@ Detected 1 error\n")
               {:tag :group
                :children [{:tag :group
                            :children [{:tag :group
-                                       :props {:on-tap {}}}]}]}))))))
+                                       :props {:on-tap {}}}]}]})
+             )))))
 
 (s/def :cat-wrapped-in-or-spec/kv (s/and
                                    sequential?
@@ -1784,6 +1825,9 @@ Detected 1 error\n"
              (s/explain-str
               :alt-spec/one-many-int-or-str
               [[:one]]))))
+    #_(expound/expound
+              :alt-spec/one-many-int-or-str
+              [[:one]])
     (s/def :alt-spec/int-or-str (s/or :i int?
                                       :s string?))
     (s/def :alt-spec/one-many-int-or-str (s/cat :bs (s/alt :one :alt-spec/int-or-str

--- a/test/expound/alpha_test.cljc
+++ b/test/expound/alpha_test.cljc
@@ -1986,9 +1986,6 @@ Detected 1 error\n"
              (s/explain-str
               :alt-spec/one-many-int-or-str
               [[:one]]))))
-    #_(expound/expound
-              :alt-spec/one-many-int-or-str
-              [[:one]])
     (s/def :alt-spec/int-or-str (s/or :i int?
                                       :s string?))
     (s/def :alt-spec/one-many-int-or-str (s/cat :bs (s/alt :one :alt-spec/int-or-str


### PR DESCRIPTION
Hello bhb, I decided to spend some time this week to fix the spec grouping issue I raised (Issue #165).

My strategy was to complete replace the previous grouping algorithm with a new one based on what form the spec takes. I deprecated the `alternation` function in `alpha.cljc`, refactored `groups` to make it cleaner and wrote two sets of new functions.

The `alpha/share-alt-tags` function figures out fi two paths branch off at the same `s/or` or an `s/alt` spec. To figure that out, the function finds the the first `path` elements after their shared prefix (ie. they are the first elements after the branch), and see if they are tags of the same `s/or` or `s/alt` spec.

To deal with recursive specs I wrote the `alpha/recursive-spec` function. That determines whether a spec's `via` path has repeating elements (to check if a spec is recursive at all) and if the smaller `via` path is a subvector of the other (to determine if the two specs are part of the same recursion).

My fixes pass all pre-existing tests (excluding tests that were failing at the time of the fork), as well as some new tests that I wrote in `alpha-test.cljc` (which I marked with `XXX`). I hope that this work is helpful to you as you work on make Expound a better library!