### PR TITLE
Verify on CI that no reflection or boxing warnings are emitted

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,9 @@ jobs:
       - run: bin/install-chrome
       - run: bin/install-clojure
       - run: sudo bin/install-node && npm install
-      - run: lein check
+      - run:
+          name: 'Check artifact isolation + lack of reflection/boxing warnings'
+          command: lein with-profile -dev,+check check 2>&1 | grep warning && exit 1 || exit 0
       - run: TEST_CHECK_FACTOR=20 lein with-profile test-common test
       - run: lein clean
       - run: lein with-profile test-web cljsbuild once test 2> >(tee -a stderr.log >&2)

--- a/project.clj
+++ b/project.clj
@@ -125,6 +125,8 @@
                    ;; need to add the compliled assets to the :clean-targets
                    :clean-targets ^{:protect false} ["resources/public/test-web"
                                                      :target-path]}
+             :check {:global-vars {*unchecked-math*     :warn-on-boxed
+                                   *warn-on-reflection* true}}
              :kaocha [:test-common
                       {:dependencies [[lambdaisland/kaocha "0.0-554"]
                                       [lambdaisland/kaocha-cloverage "0.0-41"]]}]

--- a/src/expound/alpha.cljc
+++ b/src/expound/alpha.cljc
@@ -201,7 +201,9 @@
   ([size s label-str]
    (ansi/color
     (let [prefix (str label-str label-str " " s " ")
-          chars-left (- size (count prefix))]
+          chars-left (- #?(:clj  (long size)
+                           :cljs size)
+                        (count prefix))]
       (->> (repeat chars-left label-str)
            (apply str)
            (str prefix)))

--- a/src/expound/paths.cljc
+++ b/src/expound/paths.cljc
@@ -52,14 +52,20 @@
       ;; detect a `:in` path that points to a key/value pair in a coll-of spec
       (and (map? form)
            (nat-int? k)
-           (< k (count (seq form))))
+           (< #?(:clj  (long k) 
+                 :cljs k)
+              (count (seq form))))
       (in-with-kps* (nth (seq form) k) val rst (conj in' (->KeyValuePathSegment k)))
 
       (and (map? form)
            (nat-int? k)
            (int? idx)
-           (< k (count (seq form)))
-           (< idx (count (nth (seq form) k))))
+           (< #?(:clj (long k)
+                 :cljs k)
+              (count (seq form)))
+           (< #?(:clj  (long idx)
+                 :cljs idx)
+              (count (nth (seq form) k))))
       (in-with-kps* (nth (nth (seq form) k) idx) val rst2 (conj in' (->KeyValuePathSegment k) idx))
 
       :else


### PR DESCRIPTION
This makes Expound a friendlier library for consumers that observe these warnings.