### PR TITLE
Fix bug with printing undefined specs in CLJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file. This change
 
 ## [Unreleased]
 
+### Fixed
+
+- [Bug with printing specs that are undefined in ClojureScript](https://github.com/bhb/expound/issues/198)
+
 ## [0.8.5] - 2020-06-17
 
 ### Fixed 

--- a/src/expound/printer.cljc
+++ b/src/expound/printer.cljc
@@ -247,9 +247,12 @@
     (pprint/write x :stream nil)))
 
 (defn expand-spec [spec]
-  (if (s/get-spec spec)
-    (pprint-str (s/form spec))
-    spec))
+  (let [expanded-spec (if (s/get-spec spec)
+                        (s/form spec)
+                        spec)]
+    (if (string? expanded-spec)
+      expanded-spec
+      (pprint-str expanded-spec))))
 
 (defn simple-spec-or-name [spec-name]
   (let [expanded (expand-spec spec-name)

--- a/test/expound/alpha_test.cljc
+++ b/test/expound/alpha_test.cljc
@@ -4247,3 +4247,21 @@ Detected 1 error\n"
     (is (= "Success!\n" (s/explain-str int? 1)))
     (is (= "Success!\n" (with-out-str (expound/printer (s/explain-data int? 1))))))
   (st/unstrument ['expound/printer]))
+
+(deftest undefined-key
+  (is (= "-- Spec failed --------------------
+
+  {}
+
+should contain key: :undefined-key/does-not-exist
+
+| key                           | spec                          |
+|===============================+===============================|
+| :undefined-key/does-not-exist | :undefined-key/does-not-exist |
+
+-------------------------
+Detected 1 error
+"
+         (expound/expound-str (s/keys :req [:undefined-key/does-not-exist])
+                              {}
+                              {:print-specs? false}))))


### PR DESCRIPTION
The issue is that replace works on keywords in clojure, but not in CLJS

e.g.

`(clojure.string/replace :undefined-key/does-not-exist "cljs.core/" "")` works in Clojure, but not ClojureScript