### PR TITLE
Use Specter instead of postwalk in lift-singleton-groups

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -12,7 +12,8 @@
                                ring/ring-spec {:mvn/version "0.0.4"} ; to test specs
                                org.onyxplatform/onyx-spec {:mvn/version "0.12.7.0"} ; to test specs
                                metosin/spec-tools {:mvn/version "0.8.2"}
-                               com.bhauman/spell-spec {:mvn/version "0.1.1"}}
+                               com.bhauman/spell-spec {:mvn/version "0.1.1"}
+                               com.rpl/specter {:mvn/version "1.1.3"}}
                   ;; Taken from https://github.com/boot-clj/boot/wiki/Improving-startup-time
                   :jvm-opts ["-client " "-XX:+TieredCompilation" "-XX:TieredStopAtLevel=1" "-Xmx2g" "-XX:+UseConcMarkSweepGC" "-XX:+CMSClassUnloadingEnabled" "-Xverify:none"]
                   :main-opts ["-m" "cognitect.test-runner"]}

--- a/deps.edn
+++ b/deps.edn
@@ -1,19 +1,19 @@
 {:paths ["src"]
  :aliases {;; clj -Atest
            :test {:extra-paths ["test"]
-                  :extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                                                          :sha "3cb0a9daf1cb746259dc8309b218f9211ad3b33b"}
-                               org.clojure/test.check {:mvn/version "0.10.0-alpha3"}
-                               org.clojure/clojurescript {:mvn/version "1.10.439"}
-                               com.gfredericks/test.chuck {:mvn/version "0.2.8"}
-                               orchestra {:mvn/version "2018.08.19-1"}
-                               org.clojure/core.specs.alpha {:mvn/version "0.1.24"}
-                               ring/ring-core {:mvn/version "1.6.3"} ; required to make ring-spec work, may cause issues with figwheel?
-                               ring/ring-spec {:mvn/version "0.0.4"} ; to test specs
-                               org.onyxplatform/onyx-spec {:mvn/version "0.12.7.0"} ; to test specs
-                               metosin/spec-tools {:mvn/version "0.8.2"}
-                               com.bhauman/spell-spec {:mvn/version "0.1.1"}
-                               com.rpl/specter {:mvn/version "1.1.3"}}
+                  :extra-deps {com.cognitect/test-runner      {:git/url "https://github.com/cognitect-labs/test-runner.git"
+                                                               :sha "3cb0a9daf1cb746259dc8309b218f9211ad3b33b"}
+                               org.clojure/test.check         {:mvn/version "0.10.0-alpha3"}
+                               org.clojure/clojurescript      {:mvn/version "1.10.439"}
+                               com.gfredericks/test.chuck     {:mvn/version "0.2.8"}
+                               orchestra/orchestra            {:mvn/version "2018.08.19-1"}
+                               org.clojure/core.specs.alpha   {:mvn/version "0.1.24"}
+                               ring/ring-core                 {:mvn/version "1.6.3"} ; required to make ring-spec work, may cause issues with figwheel?
+                               ring/ring-spec                 {:mvn/version "0.0.4"} ; to test specs
+                               org.onyxplatform/onyx-spec     {:mvn/version "0.12.7.0"} ; to test specs
+                               metosin/spec-tools             {:mvn/version "0.8.2"}
+                               com.bhauman/spell-spec         {:mvn/version "0.1.1"}
+                               com.rpl/specter                {:mvn/version "1.1.3"}}
                   ;; Taken from https://github.com/boot-clj/boot/wiki/Improving-startup-time
                   :jvm-opts ["-client " "-XX:+TieredCompilation" "-XX:TieredStopAtLevel=1" "-Xmx2g" "-XX:+UseConcMarkSweepGC" "-XX:+CMSClassUnloadingEnabled" "-Xverify:none"]
                   :main-opts ["-m" "cognitect.test-runner"]}
@@ -32,12 +32,12 @@
            ;; clojure -A:test:figwheel-repl
            ;; open http://localhost:9500/figwheel-extra-main/auto-testing
            :figwheel-repl {:extra-paths ["resources" "target"]
-                           :extra-deps {com.bhauman/figwheel-main {:mvn/version "0.1.9"}
+                           :extra-deps {com.bhauman/figwheel-main       {:mvn/version "0.1.9"}
                                         com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}
                                         ;;;;;;;;;;; test deps ;;;;;;;;;;;;;;
                                         ;; not necessary for tests, but just for legacy karma set up
                                         ;; until I remove it
-                                        karma-reporter {:mvn/version "3.1.0"}}
+                                        karma-reporter/karma-reporter   {:mvn/version "3.1.0"}}
                            :main-opts ["-m" "figwheel.main"
                                        "-b" "dev"
                                        "-r"]}}}


### PR DESCRIPTION
As per discussion in https://github.com/bhb/expound/issues/205

When calling for example `(expound/expound some? (d/db conn))` using [dev-local](https://docs.datomic.com/cloud/dev-local.html), `postwalk` will throw, due to `datomic.core.db.Db` implementing the map interface, thereby tricking `postwalk` into thinking that it can walk through the DB like any map (it can't).

Specter is not so easily tricked by map-like objects, and will not throw when used in place of `postwalk`.

This PR implements `lift-singleton-groups` using Specter instead of `postwalk`.