### PR TITLE
Handle low `*print-length*` and/or `*print-level*` values gracefully

### DIFF
--- a/src/expound/printer.cljc
+++ b/src/expound/printer.cljc
@@ -424,12 +424,14 @@
             (if (:show-valid-values? opts)
               (pprint-str (summary-form show-valid-values? form in))
               (pprint-str (walk/prewalk-replace {:expound.problems/irrelevant '...} (summary-form show-valid-values? form in)))))
-        [line prefix & _more] (re-find regex s)
-        highlighted-line (-> line
-                             (string/replace (re-pattern relevant) (escape-replacement
-                                                                    (re-pattern relevant)
-                                                                    (indent 0 (count prefix) (ansi/color printed-val :bad-value))))
-                             (str "\n" (ansi/color (highlight-line prefix printed-val)
-                                                   :pointer)))]
-    ;;highlighted-line
-    (no-trailing-whitespace (string/replace s line (escape-replacement line highlighted-line)))))
+        [line prefix & _more] (re-find regex s)]
+    (if-not line ;; can be nil depending on unforeseen *print-length* / *print-level* values:
+      ""
+      (let [highlighted-line (-> line
+                                 (string/replace (re-pattern relevant) (escape-replacement
+                                                                        (re-pattern relevant)
+                                                                        (indent 0 (count prefix) (ansi/color printed-val :bad-value))))
+                                 (str "\n" (ansi/color (highlight-line prefix printed-val)
+                                                       :pointer)))]
+        ;;highlighted-line
+        (no-trailing-whitespace (string/replace s line (escape-replacement line highlighted-line)))))))

--- a/test/expound/print_length_test.cljc
+++ b/test/expound/print_length_test.cljc
@@ -1,0 +1,23 @@
+(ns expound.print-length-test
+  (:require [clojure.test :as ct :refer [is deftest testing]]
+            [clojure.spec.alpha :as s]
+            [expound.alpha]
+            [clojure.string :as string]))
+
+(def the-value (range 10))
+;; Fails on the last element of the range
+(def the-spec (s/coll-of #(< % 9)))
+(def the-explanation (s/explain-data the-spec the-value))
+
+(deftest print-length-test
+  (testing "Expound works even in face of a low `*print-length*` and `*print-level*`, without throwing exceptions.
+See https://github.com/bhb/expound/issues/217"
+    (doseq [length [1 5 100 *print-length*]
+            level [1 5 100 *print-level*]
+            ;; Note that the `is` resides outside of the `binding`. Else test output itself can be affected.
+            :let [v (binding [*print-length* length
+                              *print-level* level]
+                      (with-out-str
+                        (expound.alpha/printer the-explanation)))]]
+      ;; Don't make a particularly specific test assertion, since a limited print-length isn't necessarily realistic/usual:
+      (is (not (string/blank? v))))))

--- a/test/expound/test_runner.cljs
+++ b/test/expound/test_runner.cljs
@@ -3,6 +3,7 @@
             [expound.alpha-test]
             [expound.paths-test]
             [expound.printer-test]
+            [expound.print-length-test]
             [expound.problems-test]
             [expound.test-utils]
             [expound.specs-test]


### PR DESCRIPTION
Fixes https://github.com/bhb/expound/issues/217

Cheers - V