### PR TITLE
More reliably find specs for unqualified keys in `keys` spec

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -33,7 +33,7 @@
                                   [orchestra "2020.09.18-1"]
                                   [org.clojure/core.specs.alpha "0.2.44"]
                                   [vvvvalvalval/scope-capture "0.3.2"]
-                                  [org.clojure/test.check "0.10.0"]
+                                  [org.clojure/test.check "1.1.0"]
                                   [metosin/spec-tools "0.8.2"]
                                   [ring/ring-core "1.6.3"] ; required to make ring-spec work, may cause issues with figwheel?
                                   [ring/ring-spec "0.0.4"] ; to test specs
@@ -83,7 +83,7 @@
              :kaocha [:test-common
                       {:dependencies [[lambdaisland/kaocha "0.0-565"]
                                       [lambdaisland/kaocha-cloverage "0.0-41"]]}]
-             :test-common {:dependencies [[org.clojure/test.check "0.10.0-alpha3"]
+             :test-common {:dependencies [[org.clojure/test.check "1.1.0"]
                                           [pjstadig/humane-test-output "0.9.0"]
                                           [com.gfredericks/test.chuck "0.2.10"]
                                           [orchestra "2020.09.18-1"]

--- a/project.clj
+++ b/project.clj
@@ -39,7 +39,7 @@
                                   [ring/ring-spec "0.0.4"] ; to test specs
                                   [org.onyxplatform/onyx-spec "0.13.0.0"] ; to test specs
                                   [com.gfredericks/test.chuck "0.2.10"]
-                                  [cider/cider-nrepl "0.22.4"]
+                                  [cider/cider-nrepl "0.24.0"]
                                   ]
                    :injections [(require 'sc.api)]
                    :plugins [

--- a/src/expound/alpha.cljc
+++ b/src/expound/alpha.cljc
@@ -136,7 +136,7 @@
 
 (defn ^:private named? [x]
   #?(:clj (instance? clojure.lang.Named x)
-     :cljs (implements? cljs.core.INamed x)))
+     :cljs (implements? INamed x)))
 
 (defn ^:private pr-pred* [pred]
   (cond

--- a/test/expound/alpha_test.cljc
+++ b/test/expound/alpha_test.cljc
@@ -2389,7 +2389,7 @@ Detected 2 errors\n"
 (s/def :conformers-test/string-AB
   (s/and
    ;; conform as sequence (seq function)
-   (s/conformer seq)
+   (s/conformer #(if (seqable? %) (seq %) %))
    ;; re-use previous sequence spec
    :conformers-test/string-AB-seq))
 


### PR DESCRIPTION
Fixes https://github.com/bhb/expound/issues/215