### PR TITLE
make defmsg work for for any qualified-ident? and/or form + make it traverse spec keys

### DIFF
--- a/src/expound/alpha.cljc
+++ b/src/expound/alpha.cljc
@@ -181,7 +181,7 @@
 (defn ^:private spec-w-error-message? [via pred]
   (boolean (let [last-spec (last via)]
              (and (not= ::s/unknown pred)
-                  ;; (qualified-keyword? last-spec)
+                  (qualified-keyword? last-spec)
                   (error-message last-spec)
                   (s/get-spec last-spec)))))
 

--- a/src/expound/alpha.cljc
+++ b/src/expound/alpha.cljc
@@ -1086,6 +1086,11 @@ returned an invalid value.
   (swap! registry-ref assoc k error-message)
   nil)
 
+(defn undefmsg
+  "dissociate the message for spec named `k`"
+  [k]
+  (swap! registry-ref dissoc k))
+
 #?(:clj
    (defmacro def
      "DEPRECATED: Prefer `defmsg`

--- a/src/expound/alpha.cljc
+++ b/src/expound/alpha.cljc
@@ -181,7 +181,7 @@
 (defn ^:private spec-w-error-message? [via pred]
   (boolean (let [last-spec (last via)]
              (and (not= ::s/unknown pred)
-                  (qualified-keyword? last-spec)
+                  ;; (qualified-keyword? last-spec)
                   (error-message last-spec)
                   (s/get-spec last-spec)))))
 
@@ -1017,7 +1017,7 @@ returned an invalid value.
 ;;;;;; public ;;;;;;
 
 (s/fdef error-message
-  :args (s/cat :k qualified-keyword?)
+  :args (s/cat :k any?)
   :ret (s/nilable string?))
 (defn error-message
   "Given a spec named `k`, return its human-readable error message."
@@ -1026,8 +1026,7 @@ returned an invalid value.
             (when-let [msg (get @registry-ref k)]
               (reduced msg)))
           nil
-          (util/spec-vals k))
-  (get @registry-ref k))
+          (util/spec-vals k)))
 
 (s/fdef custom-printer
   :args (s/cat :opts :expound.printer/opts)

--- a/src/expound/alpha.cljc
+++ b/src/expound/alpha.cljc
@@ -1022,6 +1022,11 @@ returned an invalid value.
 (defn error-message
   "Given a spec named `k`, return its human-readable error message."
   [k]
+  (reduce (fn [_ k]
+            (when-let [msg (get @registry-ref k)]
+              (reduced msg)))
+          nil
+          (util/spec-vals k))
   (get @registry-ref k))
 
 (s/fdef custom-printer
@@ -1072,7 +1077,8 @@ returned an invalid value.
    (print (expound-str spec form opts))))
 
 (s/fdef defmsg
-  :args (s/cat :k qualified-keyword?
+  :args (s/cat :k (s/or :ident qualified-ident?
+                        :form any?)
                :error-message string?)
   :ret nil?)
 (defn defmsg

--- a/src/expound/util.cljc
+++ b/src/expound/util.cljc
@@ -1,7 +1,27 @@
-(ns ^:no-doc expound.util)
+(ns ^:no-doc expound.util
+  (:require [clojure.spec.alpha :as s]))
 
 (def assert-message "Internal Expound assertion failed. Please report this bug at https://github.com/bhb/expound/issues")
 
 (defn nan? [x]
   #?(:clj (and (number? x) (Double/isNaN x))
      :cljs (and (number? x) (js/isNaN x))))
+
+;; some utils for spec walking
+
+(defn- accept-ident [x]
+  (when (qualified-ident? x)
+    x))
+
+(defn- parent-spec
+  "Look up for the parent spec using the spec hierarchy."
+  [k]
+  (or (accept-ident (s/get-spec k))
+      (some-> k s/get-spec s/form)))
+
+(defn spec-vals
+  "Returns all spec keys or pred "
+  ([spec-ident]
+   (->> spec-ident
+        (iterate parent-spec)
+        (take-while some?))))

--- a/src/expound/util.cljc
+++ b/src/expound/util.cljc
@@ -7,17 +7,12 @@
   #?(:clj (and (number? x) (Double/isNaN x))
      :cljs (and (number? x) (js/isNaN x))))
 
-;; some utils for spec walking
-
-(defn- accept-ident [x]
-  (when (qualified-ident? x)
-    x))
-
 (defn- parent-spec
   "Look up for the parent spec using the spec hierarchy."
   [k]
-  (or (accept-ident (s/get-spec k))
-      (some-> k s/get-spec s/form)))
+  (when-let [p (some-> k s/get-spec)]
+    (or (when (qualified-ident? p) p)
+        (s/form p))))
 
 (defn spec-vals
   "Returns all spec keys or pred "

--- a/test/expound/alpha_test.cljc
+++ b/test/expound/alpha_test.cljc
@@ -4193,6 +4193,82 @@ Detected 1 error\n"
              :defmsg-test/statuses
              :s string?)
             :oak
+            {:print-specs? false}))))
+
+  (testing "messages can be fetched from parent specs"
+
+    (reset! @#'expound/registry-ref {})
+
+    (s/def :defmsg-test/parent-string string?)
+    (s/def :defmsg-test/parent-foo :defmsg-test/parent-string)
+    (s/def :defmsg-test/parent-bar :defmsg-test/parent-foo)
+
+    (expound/defmsg :defmsg-test/parent-string "should be a string")
+    (is (= "-- Spec failed --------------------
+
+  :oak
+
+should be a string
+
+-------------------------
+Detected 1 error\n"
+           (expound/expound-str
+            :defmsg-test/parent-string
+            :oak
+            {:print-specs? false})
+
+           (expound/expound-str
+            :defmsg-test/parent-foo
+            :oak
+            {:print-specs? false})
+
+           (expound/expound-str
+            :defmsg-test/parent-bar
+            :oak
+            {:print-specs? false})))
+
+    ;; until a msg is set more precisely
+    (expound/defmsg :defmsg-test/parent-foo "should be a foo")
+    (is (= "-- Spec failed --------------------
+
+  :oak
+
+should be a foo
+
+-------------------------
+Detected 1 error\n"
+           (expound/expound-str
+            :defmsg-test/parent-foo
+            :oak
+            {:print-specs? false})))
+
+    (expound/defmsg :defmsg-test/parent-bar "should be a bar")
+    (is (= "-- Spec failed --------------------
+
+  :oak
+
+should be a bar
+
+-------------------------
+Detected 1 error\n"
+           (expound/expound-str
+            :defmsg-test/parent-bar
+            :oak
+            {:print-specs? false})))
+
+    (expound/defmsg 'clojure.core/string? "should be a string, via pred")
+    (s/def :defmsg-test/some-str string?)
+    (is (= "-- Spec failed --------------------
+
+  :oak
+
+should be a string, via pred
+
+-------------------------
+Detected 1 error\n"
+           (expound/expound-str
+            :defmsg-test/some-str
+            :oak
             {:print-specs? false})))))
 
 (deftest printer

--- a/test/expound/alpha_test.cljc
+++ b/test/expound/alpha_test.cljc
@@ -4271,6 +4271,9 @@ Detected 1 error\n"
             :oak
             {:print-specs? false})))))
 
+    ;; clean registry from this last spec, or we get failures on other tests
+    (expound/undefmsg 'clojure.core/string?)))
+
 (deftest printer
   (st/instrument ['expound/printer])
   (binding [s/*explain-out* expound/printer]
@@ -4448,4 +4451,9 @@ Detected 1 error\n"
          [::foo-string 'clojure.core/string?]))
 
   (is (= (util/spec-vals ::lone)
-         [::lone])))
+         [::lone]))
+
+  (s/def ::foo-pred nil)
+  (s/def ::foo-string nil)
+  (s/def ::bar nil)
+  (s/def ::baz nil))

--- a/test/expound/alpha_test.cljc
+++ b/test/expound/alpha_test.cljc
@@ -24,6 +24,7 @@
             [expound.printer :as printer]
             [expound.problems :as problems]
             [expound.spec-gen :as sg]
+            [expound.util :as util]
             [expound.test-utils :as test-utils]
             [spec-tools.data-spec :as ds]
             #?(:clj [orchestra.spec.test :as orch.st]
@@ -4348,3 +4349,27 @@ Detected 1 error\n"
          (expound/expound-str (s/or :k1 (s/keys :req [:keys-within-operators.user/name]
                                                 :req-un [:keys-within-operators.user/age])
                                     :k2  #(contains? % :foo)) {} {:print-specs? false}))))
+
+;;; test key spec walker
+
+(deftest test-spec-vals
+  (s/def ::foo-pred (fn [_] true))
+  (s/def ::foo-string string?)
+
+  (s/def ::bar ::foo-pred)
+  (s/def ::baz ::bar)
+
+  (is (= (util/spec-vals ::bar)
+         [::bar ::foo-pred '(clojure.core/fn [_] true)]))
+
+
+  (s/def ::bar ::foo-string)
+  (is (= (util/spec-vals ::bar)
+         [::bar ::foo-string 'clojure.core/string?]))
+
+
+  (is (= (util/spec-vals ::foo-string)
+         [::foo-string 'clojure.core/string?]))
+
+  (is (= (util/spec-vals ::lone)
+         [::lone])))


### PR DESCRIPTION
This also makes defmsg check all spec value in the spec "path"

```clj
(s/def ::str string?)
(s/def ::foo ::str)
(s/def ::bar ::foo)
```

if a defmsg is set on ::bar it will return that one first, if none is
set on on ::bar, then it would check for one on ::foo, then on ::str,
and ultimately on `string?

It also allows to set messages for full forms, so you can add a defmsg on 'clojure.core/string? '(s/coll-of string?) etc (as demonstrated in tests).

To make this happen a expound.util/spec-vals function is implemented
that will return a lazyseq of keys related to a spec, starting with
the spec key in question:

`(spec-vals ::bar)` would return `(::bar ::foo ::str 'clojure.core/string?)` from there error-message will check for these keys in the message registry until there is match. 